### PR TITLE
fix: Handle pydub dependency and configure FFmpeg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-pip freeze
+aiogram
+faster-whisper
+pydub
+pandas
+openpyxl

--- a/src/config.py
+++ b/src/config.py
@@ -10,3 +10,13 @@ BOT_TOKEN = os.getenv('BOT_TOKEN')
 if not BOT_TOKEN:
     print("Ошибка: не найден токен бота. Убедитесь, что он задан в файле .env")
     exit()
+
+# --- Настройка для конвертации аудио ---
+# Укажите здесь путь к исполняемому файлу ffmpeg.exe
+# Pydub использует FFmpeg для конвертации аудиофайлов (например, из .oga в .wav)
+#
+# Windows: "C:\\path\\to\\ffmpeg\\bin\\ffmpeg.exe" (обратите внимание на двойные слэши)
+# Linux/macOS: "/usr/bin/ffmpeg" (можно найти с помощью команды `which ffmpeg`)
+#
+# Если FFmpeg находится в системном PATH, можно оставить значение пустым (None)
+FFMPEG_PATH = os.getenv('FFMPEG_PATH')

--- a/src/handlers/voice_handlers.py
+++ b/src/handlers/voice_handlers.py
@@ -6,8 +6,13 @@ from faster_whisper import WhisperModel
 from pydub import AudioSegment
 
 # Импортируем наш новый парсер и функцию для работы с БД
+from config import FFMPEG_PATH
 from services.parser import parse_expense_text
 from services.database import add_expense
+
+# Если путь к FFmpeg указан в конфиге, задаем его для pydub
+if FFMPEG_PATH:
+    AudioSegment.converter = FFMPEG_PATH
 
 router = Router()
 


### PR DESCRIPTION
The application was failing on startup due to a `ModuleNotFoundError` for `audioop` when importing `pydub`. This error is often caused by `pydub`'s underlying dependency on an audio backend like FFmpeg not being met.

This change introduces a robust way to handle the FFmpeg dependency:
- A valid `requirements.txt` file is created to ensure a reproducible environment.
- The configuration (`src/config.py`) is updated to include an `FFMPEG_PATH` variable, allowing the user to specify the location of the FFmpeg executable.
- The voice handler (`src/handlers/voice_handlers.py`) now uses this path to configure `pydub` explicitly.

This resolves the likely cause of the crash and makes the application's dependency on FFmpeg clear and configurable.