### PR TITLE
Add .env.example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Telegram Bot Token
+# Replace "YOUR_TELEGRAM_BOT_TOKEN" with the actual token you get from BotFather on Telegram.
+BOT_TOKEN="YOUR_TELEGRAM_BOT_TOKEN"
+
+# FFmpeg Path (Optional)
+# This is the full path to the ffmpeg executable.
+# pydub needs this to convert audio files from Telegram.
+#
+# - If you add FFmpeg to your system's PATH (recommended), you can leave this blank.
+#   FFMPEG_PATH=
+#
+# - Example for Windows:
+#   FFMPEG_PATH="C:\\ffmpeg\\bin\\ffmpeg.exe"
+#
+# - Example for Linux/macOS (if not in PATH):
+#   FFMPEG_PATH="/usr/local/bin/ffmpeg"
+FFMPEG_PATH=


### PR DESCRIPTION
Adds a .env.example file to serve as a template for local environment configuration. This helps users set up their .env file without committing secrets.