### PR TITLE
fix: Resolve ffprobe path issue and improve expense parsing

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -3,6 +3,20 @@ import logging
 import shutil
 import os
 
+# --- НАЧАЛО БЛОКА ДЛЯ ИСПРАВЛЕНИЯ ПУТИ FFMPEG ---
+# Этот блок должен быть в самом верху, до импорта других модулей, использующих ffmpeg.
+# Он добавляет директорию с ffmpeg в системный PATH, чтобы pydub нашел и ffmpeg, и ffprobe.
+try:
+    from config import FFMPEG_PATH
+    if FFMPEG_PATH and os.path.isfile(FFMPEG_PATH):
+        ffmpeg_dir = os.path.dirname(FFMPEG_PATH)
+        os.environ["PATH"] = str(ffmpeg_dir) + os.pathsep + os.environ.get("PATH", "")
+        print(f"INFO: FFmpeg directory '{ffmpeg_dir}' was successfully added to the system PATH.")
+except ImportError:
+    print("INFO: Could not import FFMPEG_PATH from config. Relying on system PATH for FFmpeg.")
+    pass
+# --- КОНЕЦ БЛОКА ---
+
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties  # <--- ДОБАВЬТЕ ЭТУ СТРОКУ
 from aiogram.filters import CommandStart


### PR DESCRIPTION
This commit addresses two separate issues:

1.  A `FileNotFoundError` for `ffprobe.exe` on Windows. The `pydub` library was unable to locate `ffprobe.exe` because its directory was not in the system PATH. This change modifies `bot.py` to programmatically add the directory of the configured `FFMPEG_PATH` to the system's `PATH` at startup. This allows `pydub` to find both `ffmpeg.exe` and `ffprobe.exe` reliably.

2.  Improved LLM-based expense parsing. The AI was failing to parse expense commands that started with the noun "Расход". This change adds a new, more specific example to the few-shot prompt in `src/services/vertex_ai.py` to teach the model how to handle this sentence structure, making the parser more robust.